### PR TITLE
Added Intrinsics and some performance optimisations

### DIFF
--- a/src/NaCl.Core/Base/ChaCha20Base.cs
+++ b/src/NaCl.Core/Base/ChaCha20Base.cs
@@ -64,6 +64,19 @@
             ArrayUtils.StoreArray16UInt32LittleEndian(block, 0, state);
         }
 
+#if INTRINSICS
+        public override unsafe void ProcessStream(ReadOnlySpan<byte> nonce, Span<byte> output, ReadOnlySpan<byte> input, int initialCounter, int offset = 0)
+        {
+            Span<uint> state = stackalloc uint[BLOCK_SIZE_IN_INTS];
+            SetInitialState(state, nonce, initialCounter);
+            fixed (uint* x = state)
+            fixed (byte* m = input, c = output.Slice(offset))
+            {
+                ChaCha20BaseIntrinsics.ChaCha20(x, m, c, (ulong)input.Length);
+            }
+        }
+#endif
+
         /// <summary>
         /// Process a pseudorandom keystream block, converting the key and part of the <paramref name="nonce"> into a <paramref name="subkey">, and the remainder of the <paramref name="nonce">.
         /// </summary>

--- a/src/NaCl.Core/Base/ChaCha20BaseIntrinsics.cs
+++ b/src/NaCl.Core/Base/ChaCha20BaseIntrinsics.cs
@@ -1,0 +1,570 @@
+﻿#if INTRINSICS
+#pragma warning disable IDE0007 // Use implicit type
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace NaCl.Core.Base
+{
+    public static class ChaCha20BaseIntrinsics
+    {
+        private static Vector128<byte> rot8_128 = Vector128.Create((byte)3, 0, 1, 2, 7, 4, 5, 6, 11, 8, 9, 10, 15, 12, 13, 14);
+        private static Vector128<byte> rot16_128 = Vector128.Create((byte)2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13);
+        private static Vector256<byte> rot8_256 = Vector256.Create((byte)3, 0, 1, 2, 7, 4, 5, 6, 11, 8, 9, 10, 15, 12, 13, 14, 3, 0, 1, 2, 7, 4, 5, 6, 11, 8, 9, 10, 15, 12, 13, 14);
+        private static Vector256<byte> rot16_256 = Vector256.Create((byte)2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13, 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void ChaCha20(uint* x, byte* m, byte* c, ulong bytes)
+        {
+            if (Avx2.IsSupported && bytes >= 512)
+            {
+                Vector256<uint> x_0 = Vector256.Create(x[0]);
+                Vector256<uint> x_1 = Vector256.Create(x[1]);
+                Vector256<uint> x_2 = Vector256.Create(x[2]);
+                Vector256<uint> x_3 = Vector256.Create(x[3]);
+                Vector256<uint> x_4 = Vector256.Create(x[4]);
+                Vector256<uint> x_5 = Vector256.Create(x[5]);
+                Vector256<uint> x_6 = Vector256.Create(x[6]);
+                Vector256<uint> x_7 = Vector256.Create(x[7]);
+                Vector256<uint> x_8 = Vector256.Create(x[8]);
+                Vector256<uint> x_9 = Vector256.Create(x[9]);
+                Vector256<uint> x_10 = Vector256.Create(x[10]);
+                Vector256<uint> x_11 = Vector256.Create(x[11]);
+                Vector256<uint> x_12;
+                Vector256<uint> x_13;
+                Vector256<uint> x_14 = Vector256.Create(x[14]);
+                Vector256<uint> x_15 = Vector256.Create(x[15]);
+
+                Vector256<uint> orig0 = x_0;
+                Vector256<uint> orig1 = x_1;
+                Vector256<uint> orig2 = x_2;
+                Vector256<uint> orig3 = x_3;
+                Vector256<uint> orig4 = x_4;
+                Vector256<uint> orig5 = x_5;
+                Vector256<uint> orig6 = x_6;
+                Vector256<uint> orig7 = x_7;
+                Vector256<uint> orig8 = x_8;
+                Vector256<uint> orig9 = x_9;
+                Vector256<uint> orig10 = x_10;
+                Vector256<uint> orig11 = x_11;
+                Vector256<uint> orig12;
+                Vector256<uint> orig13;
+                Vector256<uint> orig14 = x_14;
+                Vector256<uint> orig15 = x_15;
+
+                while (bytes >= 512)
+                {
+                    Vector256<uint> addv12 = Vector256.Create(0, 1, 2, 3).AsUInt32();
+                    Vector256<uint> addv13 = Vector256.Create(4, 5, 6, 7).AsUInt32();
+                    Vector256<uint> permute = Vector256.Create(0, 1, 4, 5, 2, 3, 6, 7).AsUInt32();
+                    Vector256<uint> t12, t13;
+                    x_0 = orig0;
+                    x_1 = orig1;
+                    x_2 = orig2;
+                    x_3 = orig3;
+                    x_4 = orig4;
+                    x_5 = orig5;
+                    x_6 = orig6;
+                    x_7 = orig7;
+                    x_8 = orig8;
+                    x_9 = orig9;
+                    x_10 = orig10;
+                    x_11 = orig11;
+                    x_14 = orig14;
+                    x_15 = orig15;
+                    uint in12 = x[12];
+                    uint in13 = x[13];
+                    ulong in1213 = in12 | ((ulong)in13 << 32);
+                    x_12 = x_13 = Avx2.BroadcastScalarToVector256(Sse2.X64.ConvertScalarToVector128UInt64(in1213)).AsUInt32();
+                    t12 = Avx2.Add(addv12.AsUInt64(), x_12.AsUInt64()).AsUInt32();
+                    t13 = Avx2.Add(addv13.AsUInt64(), x_13.AsUInt64()).AsUInt32();
+                    x_12 = Avx2.UnpackLow(t12, t13);
+                    x_13 = Avx2.UnpackHigh(t12, t13);
+                    t12 = Avx2.UnpackLow(x_12, x_13);
+                    t13 = Avx2.UnpackHigh(x_12, x_13);
+                    x_12 = Avx2.PermuteVar8x32(t12, permute);
+                    x_13 = Avx2.PermuteVar8x32(t13, permute);
+
+                    orig12 = x_12;
+                    orig13 = x_13;
+
+                    in1213 += 8;
+
+                    x[12] = (uint)(in1213 & 0xFFFFFFFF);
+                    x[13] = (uint)((in1213 >> 32) & 0xFFFFFFFF);
+                    for (int i = 0; i < 20; i += 2)
+                    {
+                        Vec256Round(ref x_0, ref x_4, ref x_8, ref x_12, ref x_1, ref x_5, ref x_9, ref x_13, ref x_2, ref x_6, ref x_10, ref x_14, ref x_3, ref x_7, ref x_11, ref x_15);
+                        Vec256Round(ref x_0, ref x_5, ref x_10, ref x_15, ref x_1, ref x_6, ref x_11, ref x_12, ref x_2, ref x_7, ref x_8, ref x_13, ref x_3, ref x_4, ref x_9, ref x_14);
+                    }
+
+                    Vector256<uint> t_0, t_1, t_2, t_3, t_4, t_5, t_6, t_7, t_8, t_9, t_10, t_11, t_12, t_13, t_14, t_15;
+                    t_0 = t_1 = t_2 = t_3 = t_4 = t_5 = t_6 = t_7 = t_8 = t_9 = t_10 = t_11 = t_12 = t_13 = t_14 = t_15 = Vector256.Create((uint)0);
+                    // ONEOCTO enter
+                    OneQuadUnpack(ref x_0, ref x_1, ref x_2, ref x_3, ref t_0, ref t_1, ref t_2, ref t_3, ref orig0, ref orig1, ref orig2, ref orig3);
+                    OneQuadUnpack(ref x_4, ref x_5, ref x_6, ref x_7, ref t_4, ref t_5, ref t_6, ref t_7, ref orig4, ref orig5, ref orig6, ref orig7);
+                    t_0 = Avx2.Permute2x128(x_0, x_4, 0x20);
+                    t_4 = Avx2.Permute2x128(x_0, x_4, 0x31);
+                    t_1 = Avx2.Permute2x128(x_1, x_5, 0x20);
+                    t_5 = Avx2.Permute2x128(x_1, x_5, 0x31);
+                    t_2 = Avx2.Permute2x128(x_2, x_6, 0x20);
+                    t_6 = Avx2.Permute2x128(x_2, x_6, 0x31);
+                    t_3 = Avx2.Permute2x128(x_3, x_7, 0x20);
+                    t_7 = Avx2.Permute2x128(x_3, x_7, 0x31);
+                    t_0 = Avx2.Xor(t_0, Avx.LoadVector256(m).AsUInt32());
+                    t_1 = Avx2.Xor(t_1, Avx.LoadVector256(m + 64).AsUInt32());
+                    t_2 = Avx2.Xor(t_2, Avx.LoadVector256(m + 128).AsUInt32());
+                    t_3 = Avx2.Xor(t_3, Avx.LoadVector256(m + 192).AsUInt32());
+                    t_4 = Avx2.Xor(t_4, Avx.LoadVector256(m + 256).AsUInt32());
+                    t_5 = Avx2.Xor(t_5, Avx.LoadVector256(m + 320).AsUInt32());
+                    t_6 = Avx2.Xor(t_6, Avx.LoadVector256(m + 384).AsUInt32());
+                    t_7 = Avx2.Xor(t_7, Avx.LoadVector256(m + 448).AsUInt32());
+                    Avx.Store(c, t_0.AsByte());
+                    Avx.Store(c + 64, t_1.AsByte());
+                    Avx.Store(c + 128, t_2.AsByte());
+                    Avx.Store(c + 192, t_3.AsByte());
+                    Avx.Store(c + 256, t_4.AsByte());
+                    Avx.Store(c + 320, t_5.AsByte());
+                    Avx.Store(c + 384, t_6.AsByte());
+                    Avx.Store(c + 448, t_7.AsByte());
+                    // ONEOCTO exit
+
+                    m += 32;
+                    c += 32;
+
+                    // ONEOCTO enter
+                    OneQuadUnpack(ref x_8, ref x_9, ref x_10, ref x_11, ref t_8, ref t_9, ref t_10, ref t_11, ref orig8, ref orig9, ref orig10, ref orig11);
+                    OneQuadUnpack(ref x_12, ref x_13, ref x_14, ref x_15, ref t_12, ref t_13, ref t_14, ref t_15, ref orig12, ref orig13, ref orig14, ref orig15);
+                    t_8 = Avx2.Permute2x128(x_8, x_12, 0x20);
+                    t_12 = Avx2.Permute2x128(x_8, x_12, 0x31);
+                    t_9 = Avx2.Permute2x128(x_9, x_13, 0x20);
+                    t_13 = Avx2.Permute2x128(x_9, x_13, 0x31);
+                    t_10 = Avx2.Permute2x128(x_10, x_14, 0x20);
+                    t_14 = Avx2.Permute2x128(x_10, x_14, 0x31);
+                    t_11 = Avx2.Permute2x128(x_11, x_15, 0x20);
+                    t_15 = Avx2.Permute2x128(x_11, x_15, 0x31);
+                    t_8 = Avx2.Xor(t_8, Avx.LoadVector256(m).AsUInt32());
+                    t_9 = Avx2.Xor(t_9, Avx.LoadVector256(m + 64).AsUInt32());
+                    t_10 = Avx2.Xor(t_10, Avx.LoadVector256(m + 128).AsUInt32());
+                    t_11 = Avx2.Xor(t_11, Avx.LoadVector256(m + 192).AsUInt32());
+                    t_12 = Avx2.Xor(t_12, Avx.LoadVector256(m + 256).AsUInt32());
+                    t_13 = Avx2.Xor(t_13, Avx.LoadVector256(m + 320).AsUInt32());
+                    t_14 = Avx2.Xor(t_14, Avx.LoadVector256(m + 384).AsUInt32());
+                    t_15 = Avx2.Xor(t_15, Avx.LoadVector256(m + 448).AsUInt32());
+                    Avx.Store(c, t_8.AsByte());
+                    Avx.Store(c + 64, t_9.AsByte());
+                    Avx.Store(c + 128, t_10.AsByte());
+                    Avx.Store(c + 192, t_11.AsByte());
+                    Avx.Store(c + 256, t_12.AsByte());
+                    Avx.Store(c + 320, t_13.AsByte());
+                    Avx.Store(c + 384, t_14.AsByte());
+                    Avx.Store(c + 448, t_15.AsByte());
+                    // ONEOCTO exit
+                    m -= 32;
+                    c -= 32;
+                    bytes -= 512;
+                    c += 512;
+                    m += 512;
+                }
+            }
+            if (bytes >= 256)
+            {
+                Vector128<uint> x_0 = Vector128.Create(x[0]);
+                Vector128<uint> x_1 = Vector128.Create(x[1]);
+                Vector128<uint> x_2 = Vector128.Create(x[2]);
+                Vector128<uint> x_3 = Vector128.Create(x[3]);
+                Vector128<uint> x_4 = Vector128.Create(x[4]);
+                Vector128<uint> x_5 = Vector128.Create(x[5]);
+                Vector128<uint> x_6 = Vector128.Create(x[6]);
+                Vector128<uint> x_7 = Vector128.Create(x[7]);
+                Vector128<uint> x_8 = Vector128.Create(x[8]);
+                Vector128<uint> x_9 = Vector128.Create(x[9]);
+                Vector128<uint> x_10 = Vector128.Create(x[10]);
+                Vector128<uint> x_11 = Vector128.Create(x[11]);
+                Vector128<uint> x_12;
+                Vector128<uint> x_13;
+                Vector128<uint> x_14 = Vector128.Create(x[14]);
+                Vector128<uint> x_15 = Vector128.Create(x[15]);
+                Vector128<uint> orig0 = x_0;
+                Vector128<uint> orig1 = x_1;
+                Vector128<uint> orig2 = x_2;
+                Vector128<uint> orig3 = x_3;
+                Vector128<uint> orig4 = x_4;
+                Vector128<uint> orig5 = x_5;
+                Vector128<uint> orig6 = x_6;
+                Vector128<uint> orig7 = x_7;
+                Vector128<uint> orig8 = x_8;
+                Vector128<uint> orig9 = x_9;
+                Vector128<uint> orig10 = x_10;
+                Vector128<uint> orig11 = x_11;
+                Vector128<uint> orig12;
+                Vector128<uint> orig13;
+                Vector128<uint> orig14 = x_14;
+                Vector128<uint> orig15 = x_15;
+                Vector128<uint> t12, t13;
+
+                while (bytes >= 256)
+                {
+                    Vector128<uint> addv12 = Vector128.Create(0, 1).AsUInt32();
+                    Vector128<uint> addv13 = Vector128.Create(2, 3).AsUInt32();
+
+                    x_0 = orig0;
+                    x_1 = orig1;
+                    x_2 = orig2;
+                    x_3 = orig3;
+                    x_4 = orig4;
+                    x_5 = orig5;
+                    x_6 = orig6;
+                    x_7 = orig7;
+                    x_8 = orig8;
+                    x_9 = orig9;
+                    x_10 = orig10;
+                    x_11 = orig11;
+                    x_14 = orig14;
+                    x_15 = orig15;
+
+                    uint in12 = x[12];
+                    uint in13 = x[13];
+                    ulong in1213 = in12 | ((ulong)in13) << 32;
+                    t12 = Vector128.Create(in1213).AsUInt32();
+                    t13 = Vector128.Create(in1213).AsUInt32();
+
+                    x_12 = Sse2.Add(Vector128.AsUInt64<uint>(addv12), Vector128.AsUInt64<uint>(t12)).AsUInt32();
+                    x_13 = Sse2.Add(Vector128.AsUInt64<uint>(addv13), Vector128.AsUInt64<uint>(t13)).AsUInt32();
+
+                    t12 = Sse2.UnpackLow(x_12, x_13);
+                    t13 = Sse2.UnpackHigh(x_12, x_13);
+
+                    x_12 = Sse2.UnpackLow(t12, t13);
+                    x_13 = Sse2.UnpackHigh(t12, t13);
+
+                    orig12 = x_12;
+                    orig13 = x_13;
+
+                    in1213 += 4;
+
+                    x[12] = (uint)(in1213 & 0xFFFFFFFF);
+                    x[13] = (uint)(in1213 >> 32 & 0xFFFFFFFF);
+
+                    for (int i = 0; i < 20; i += 2)
+                    {
+                        Vec128QuarterRound(ref x_0, ref x_4, ref x_8, ref x_12);
+                        Vec128QuarterRound(ref x_1, ref x_5, ref x_9, ref x_13);
+                        Vec128QuarterRound(ref x_2, ref x_6, ref x_10, ref x_14);
+                        Vec128QuarterRound(ref x_3, ref x_7, ref x_11, ref x_15);
+                        Vec128QuarterRound(ref x_0, ref x_5, ref x_10, ref x_15);
+                        Vec128QuarterRound(ref x_1, ref x_6, ref x_11, ref x_12);
+                        Vec128QuarterRound(ref x_2, ref x_7, ref x_8, ref x_13);
+                        Vec128QuarterRound(ref x_3, ref x_4, ref x_9, ref x_14);
+                    }
+                    OneQuad(ref x_0, ref x_1, ref x_2, ref x_3, ref orig0, ref orig1, ref orig2, ref orig3, m, c);
+                    m += 16;
+                    c += 16;
+                    OneQuad(ref x_4, ref x_5, ref x_6, ref x_7, ref orig4, ref orig5, ref orig6, ref orig7, m, c);
+                    m += 16;
+                    c += 16;
+                    OneQuad(ref x_8, ref x_9, ref x_10, ref x_11, ref orig8, ref orig9, ref orig10, ref orig11, m, c);
+                    m += 16;
+                    c += 16;
+                    OneQuad(ref x_12, ref x_13, ref x_14, ref x_15, ref orig12, ref orig13, ref orig14, ref orig15, m, c);
+                    m -= 48;
+                    c -= 48;
+                    bytes -= 256;
+                    c += 256;
+                    m += 256;
+                }
+            }
+            while (bytes >= 64)
+            {
+                Vector128<uint> x_0 = Sse2.LoadVector128(x);
+                Vector128<uint> x_1 = Sse2.LoadVector128(x + 4);
+                Vector128<uint> x_2 = Sse2.LoadVector128(x + 8);
+                Vector128<uint> x_3 = Sse2.LoadVector128(x + 12);
+                Vector128<uint> t_1;
+
+                for (int i = 0; i < 20; i += 2)
+                {
+                    x_0 = Sse2.Add(x_0, x_1);
+                    x_3 = Sse2.Xor(x_3, x_0);
+                    x_3 = Ssse3.Shuffle(x_3.AsByte(), rot16_128).AsUInt32();
+
+                    x_2 = Sse2.Add(x_2, x_3);
+                    x_1 = Sse2.Xor(x_1, x_2);
+
+                    t_1 = x_1;
+                    x_1 = Sse2.ShiftLeftLogical(x_1, 12);
+                    t_1 = Sse2.ShiftRightLogical(t_1, 20);
+                    x_1 = Sse2.Xor(x_1, t_1);
+
+                    x_0 = Sse2.Add(x_0, x_1);
+                    x_3 = Sse2.Xor(x_3, x_0);
+                    x_0 = Sse2.Shuffle(x_0, 147);
+                    x_3 = Ssse3.Shuffle(x_3.AsByte(), rot8_128).AsUInt32();
+
+                    x_2 = Sse2.Add(x_2, x_3);
+                    x_3 = Sse2.Shuffle(x_3, 78);
+                    x_1 = Sse2.Xor(x_1, x_2);
+                    x_2 = Sse2.Shuffle(x_2, 57);
+
+                    t_1 = x_1;
+                    x_1 = Sse2.ShiftLeftLogical(x_1, 7);
+                    t_1 = Sse2.ShiftRightLogical(t_1, 25);
+                    x_1 = Sse2.Xor(x_1, t_1);
+
+                    x_0 = Sse2.Add(x_0, x_1);
+                    x_3 = Sse2.Xor(x_3, x_0);
+                    x_3 = Ssse3.Shuffle(x_3.AsByte(), rot16_128).AsUInt32();
+
+                    x_2 = Sse2.Add(x_2, x_3);
+                    x_1 = Sse2.Xor(x_1, x_2);
+
+                    t_1 = x_1;
+                    x_1 = Sse2.ShiftLeftLogical(x_1, 12);
+                    t_1 = Sse2.ShiftRightLogical(t_1, 20);
+                    x_1 = Sse2.Xor(x_1, t_1);
+
+                    x_0 = Sse2.Add(x_0, x_1);
+                    x_3 = Sse2.Xor(x_3, x_0);
+                    x_0 = Sse2.Shuffle(x_0, 57);
+                    x_3 = Ssse3.Shuffle(x_3.AsByte(), rot8_128).AsUInt32();
+
+                    x_2 = Sse2.Add(x_2, x_3);
+                    x_3 = Sse2.Shuffle(x_3, 78);
+                    x_1 = Sse2.Xor(x_1, x_2);
+                    x_2 = Sse2.Shuffle(x_2, 147);
+
+                    t_1 = x_1;
+                    x_1 = Sse2.ShiftLeftLogical(x_1, 7);
+                    t_1 = Sse2.ShiftRightLogical(t_1, 25);
+                    x_1 = Sse2.Xor(x_1, t_1);
+                }
+                x_0 = Sse2.Add(x_0, Sse2.LoadVector128(x));
+                x_1 = Sse2.Add(x_1, Sse2.LoadVector128(x + 4));
+                x_2 = Sse2.Add(x_2, Sse2.LoadVector128(x + 8));
+                x_3 = Sse2.Add(x_3, Sse2.LoadVector128(x + 12));
+                x_0 = Sse2.Xor(x_0.AsByte(), Sse2.LoadVector128(m)).AsUInt32();
+                x_1 = Sse2.Xor(x_1.AsByte(), Sse2.LoadVector128(m + 16)).AsUInt32();
+                x_2 = Sse2.Xor(x_2.AsByte(), Sse2.LoadVector128(m + 32)).AsUInt32();
+                x_3 = Sse2.Xor(x_3.AsByte(), Sse2.LoadVector128(m + 48)).AsUInt32();
+                Sse2.Store(c, x_0.AsByte());
+                Sse2.Store(c + 16, x_1.AsByte());
+                Sse2.Store(c + 32, x_2.AsByte());
+                Sse2.Store(c + 48, x_3.AsByte());
+
+                uint in12 = x[12];
+                uint in13 = x[13];
+                in12++;
+                if (in12 == 0)
+                {
+                    in13++;
+                }
+                x[12] = in12;
+                x[13] = in13;
+
+                bytes -= 64;
+                c += 64;
+                m += 64;
+            }
+            if (bytes > 0)
+            {
+                Vector128<uint> x_0 = Sse2.LoadVector128(x);
+                Vector128<uint> x_1 = Sse2.LoadVector128(x + 4);
+                Vector128<uint> x_2 = Sse2.LoadVector128(x + 8);
+                Vector128<uint> x_3 = Sse2.LoadVector128(x + 12);
+                Vector128<uint> t_1;
+                for (int i = 0; i < 20; i += 2)
+                {
+                    x_0 = Sse2.Add(x_0, x_1);
+                    x_3 = Sse2.Xor(x_3, x_0);
+                    x_3 = Ssse3.Shuffle(x_3.AsByte(), rot16_128).AsUInt32();
+
+                    x_2 = Sse2.Add(x_2, x_3);
+                    x_1 = Sse2.Xor(x_1, x_2);
+
+                    t_1 = x_1;
+                    x_1 = Sse2.ShiftLeftLogical(x_1, 12);
+                    t_1 = Sse2.ShiftRightLogical(t_1, 20);
+                    x_1 = Sse2.Xor(x_1, t_1);
+
+                    x_0 = Sse2.Add(x_0, x_1);
+                    x_3 = Sse2.Xor(x_3, x_0);
+                    x_0 = Sse2.Shuffle(x_0, 0x93);
+                    x_3 = Ssse3.Shuffle(x_3.AsByte(), rot8_128).AsUInt32();
+
+                    x_2 = Sse2.Add(x_2, x_3);
+                    x_3 = Sse2.Shuffle(x_3, 0x4e);
+                    x_1 = Sse2.Xor(x_1, x_2);
+                    x_2 = Sse2.Shuffle(x_2, 0x39);
+
+                    t_1 = x_1;
+                    x_1 = Sse2.ShiftLeftLogical(x_1, 7);
+                    t_1 = Sse2.ShiftRightLogical(t_1, 25);
+                    x_1 = Sse2.Xor(x_1, t_1);
+
+                    x_0 = Sse2.Add(x_0, x_1);
+                    x_3 = Sse2.Xor(x_3, x_0);
+                    x_3 = Ssse3.Shuffle(x_3.AsByte(), rot16_128).AsUInt32();
+
+                    x_2 = Sse2.Add(x_2, x_3);
+                    x_1 = Sse2.Xor(x_1, x_2);
+
+                    t_1 = x_1;
+                    x_1 = Sse2.ShiftLeftLogical(x_1, 12);
+                    t_1 = Sse2.ShiftRightLogical(t_1, 20);
+                    x_1 = Sse2.Xor(x_1, t_1);
+
+                    x_0 = Sse2.Add(x_0, x_1);
+                    x_3 = Sse2.Xor(x_3, x_0);
+                    x_0 = Sse2.Shuffle(x_0, 0x39);
+                    x_3 = Ssse3.Shuffle(x_3.AsByte(), rot8_128).AsUInt32();
+
+                    x_2 = Sse2.Add(x_2, x_3);
+                    x_3 = Sse2.Shuffle(x_3, 0x4e);
+                    x_1 = Sse2.Xor(x_1, x_2);
+                    x_2 = Sse2.Shuffle(x_2, 0x93);
+
+                    t_1 = x_1;
+                    x_1 = Sse2.ShiftLeftLogical(x_1, 7);
+                    t_1 = Sse2.ShiftRightLogical(t_1, 25);
+                    x_1 = Sse2.Xor(x_1, t_1);
+                }
+                x_0 = Sse2.Add(x_0, Sse2.LoadVector128(x));
+                x_1 = Sse2.Add(x_1, Sse2.LoadVector128(x + 4));
+                x_2 = Sse2.Add(x_2, Sse2.LoadVector128(x + 8));
+                x_3 = Sse2.Add(x_3, Sse2.LoadVector128(x + 12));
+                byte* partialblock = stackalloc byte[64];
+                Sse2.Store(partialblock, Vector128.AsByte(x_0));
+                Sse2.Store(partialblock + 16, Vector128.AsByte(x_1));
+                Sse2.Store(partialblock + 32, Vector128.AsByte(x_2));
+                Sse2.Store(partialblock + 48, Vector128.AsByte(x_3));
+
+                for (ulong i = 0; i < bytes; i++)
+                {
+                    c[i] = (byte)(m[i] ^ partialblock[i]);
+                }
+                for (int n = 0; n < 64 / sizeof(int); n++)
+                {
+                    ((int*)partialblock)[n] = 0;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void OneQuad(ref Vector128<uint> x_A, ref Vector128<uint> x_B, ref Vector128<uint> x_C, ref Vector128<uint> x_D, ref Vector128<uint> origA, ref Vector128<uint> origB, ref Vector128<uint> origC, ref Vector128<uint> origD, byte* m, byte* c)
+        {
+            Vector128<uint> t_A, t_B, t_C, t_D, t0, t1, t2, t3;
+            x_A = Sse2.Add(x_A, origA);
+            x_B = Sse2.Add(x_B, origB);
+            x_C = Sse2.Add(x_C, origC);
+            x_D = Sse2.Add(x_D, origD);
+            t_A = Sse2.UnpackLow(x_A, x_B);
+            t_B = Sse2.UnpackLow(x_C, x_D);
+            t_C = Sse2.UnpackHigh(x_A, x_B);
+            t_D = Sse2.UnpackHigh(x_C, x_D);
+            x_A = Sse2.UnpackLow(t_A.AsUInt64(), t_B.AsUInt64()).AsUInt32();
+            x_B = Sse2.UnpackHigh(t_A.AsUInt64(), t_B.AsUInt64()).AsUInt32();
+            x_C = Sse2.UnpackLow(t_C.AsUInt64(), t_D.AsUInt64()).AsUInt32();
+            x_D = Sse2.UnpackHigh(t_C.AsUInt64(), t_D.AsUInt64()).AsUInt32();
+            t0 = Sse2.Xor(x_A.AsByte(), Sse2.LoadVector128(m)).AsUInt32();
+            Sse2.Store(c, t0.AsByte());
+            t1 = Sse2.Xor(x_B.AsByte(), Sse2.LoadVector128(m + 64)).AsUInt32();
+            Sse2.Store(c + 64, t1.AsByte());
+            t2 = Sse2.Xor(x_C.AsByte(), Sse2.LoadVector128(m + 128)).AsUInt32();
+            Sse2.Store(c + 128, t2.AsByte());
+            t3 = Sse2.Xor(x_D.AsByte(), Sse2.LoadVector128(m + 192)).AsUInt32();
+            Sse2.Store(c + 192, t3.AsByte());
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Vec128QuarterRound(ref Vector128<uint> x_A, ref Vector128<uint> x_B, ref Vector128<uint> x_C, ref Vector128<uint> x_D)
+        {
+            Vector128<uint> t_A, t_C;
+            x_A = Sse2.Add(x_A, x_B);
+            t_A = Sse2.Xor(x_D, x_A);
+            x_D = Ssse3.Shuffle(t_A.AsByte(), rot16_128).AsUInt32();
+            x_C = Sse2.Add(x_C, x_D);
+            t_C = Sse2.Xor(x_B, x_C);
+            x_B = Sse2.Or(Sse2.ShiftLeftLogical(t_C, 12), Sse2.ShiftRightLogical(t_C, 20));
+            x_A = Sse2.Add(x_A, x_B);
+            t_A = Sse2.Xor(x_D, x_A);
+            x_D = Ssse3.Shuffle(t_A.AsByte(), rot8_128).AsUInt32();
+            x_C = Sse2.Add(x_C, x_D);
+            t_C = Sse2.Xor(x_B, x_C);
+            x_B = Sse2.Or(Sse2.ShiftLeftLogical(t_C, 7), Sse2.ShiftRightLogical(t_C, 25));
+        }
+
+        // 512 byte methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector256<uint> Vector256Rotate(Vector256<uint> a, byte imm) => Avx2.Or(Avx2.ShiftLeftLogical(a, imm), Avx2.ShiftRightLogical(a, (byte)(32 - imm)));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Vec256Round(ref Vector256<uint> A1, ref Vector256<uint> B1, ref Vector256<uint> C1, ref Vector256<uint> D1, ref Vector256<uint> A2, ref Vector256<uint> B2, ref Vector256<uint> C2, ref Vector256<uint> D2, ref Vector256<uint> A3, ref Vector256<uint> B3, ref Vector256<uint> C3, ref Vector256<uint> D3, ref Vector256<uint> A4, ref Vector256<uint> B4, ref Vector256<uint> C4, ref Vector256<uint> D4)
+        {
+            Vector256Line1(ref A1, ref B1, ref C1, ref D1);
+            Vector256Line1(ref A2, ref B2, ref C2, ref D2);
+            Vector256Line1(ref A3, ref B3, ref C3, ref D3);
+            Vector256Line1(ref A4, ref B4, ref C4, ref D4);
+            Vector256Line2(ref A1, ref B1, ref C1, ref D1);
+            Vector256Line2(ref A2, ref B2, ref C2, ref D2);
+            Vector256Line2(ref A3, ref B3, ref C3, ref D3);
+            Vector256Line2(ref A4, ref B4, ref C4, ref D4);
+            Vector256Line3(ref A1, ref B1, ref C1, ref D1);
+            Vector256Line3(ref A2, ref B2, ref C2, ref D2);
+            Vector256Line3(ref A3, ref B3, ref C3, ref D3);
+            Vector256Line3(ref A4, ref B4, ref C4, ref D4);
+            Vector256Line4(ref A1, ref B1, ref C1, ref D1);
+            Vector256Line4(ref A2, ref B2, ref C2, ref D2);
+            Vector256Line4(ref A3, ref B3, ref C3, ref D3);
+            Vector256Line4(ref A4, ref B4, ref C4, ref D4);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Vector256Line1(ref Vector256<uint> x_A, ref Vector256<uint> x_B, ref Vector256<uint> x_C, ref Vector256<uint> x_D)
+        {
+            x_A = Avx2.Add(x_A, x_B);
+            x_D = Avx2.Shuffle(Avx2.Xor(x_D, x_A).AsByte(), rot16_256).AsUInt32();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Vector256Line2(ref Vector256<uint> x_A, ref Vector256<uint> x_B, ref Vector256<uint> x_C, ref Vector256<uint> x_D)
+        {
+            x_C = Avx2.Add(x_C, x_D);
+            x_B = Vector256Rotate(Avx2.Xor(x_B, x_C), 12);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Vector256Line3(ref Vector256<uint> x_A, ref Vector256<uint> x_B, ref Vector256<uint> x_C, ref Vector256<uint> x_D)
+        {
+            x_A = Avx2.Add(x_A, x_B);
+            x_D = Avx2.Shuffle(Avx2.Xor(x_D, x_A).AsByte(), rot8_256).AsUInt32();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Vector256Line4(ref Vector256<uint> x_A, ref Vector256<uint> x_B, ref Vector256<uint> x_C, ref Vector256<uint> x_D)
+        {
+            x_C = Avx2.Add(x_C, x_D);
+            x_B = Vector256Rotate(Avx2.Xor(x_B, x_C), 7);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void OneQuadUnpack(ref Vector256<uint> x_A, ref Vector256<uint> x_B, ref Vector256<uint> x_C, ref Vector256<uint> x_D, ref Vector256<uint> t_A, ref Vector256<uint> t_B, ref Vector256<uint> t_C, ref Vector256<uint> t_D, ref Vector256<uint> orig_A, ref Vector256<uint> orig_B, ref Vector256<uint> orig_C, ref Vector256<uint> orig_D)
+        {
+            x_A = Avx2.Add(x_A, orig_A);
+            x_B = Avx2.Add(x_B, orig_B);
+            x_C = Avx2.Add(x_C, orig_C);
+            x_D = Avx2.Add(x_D, orig_D);
+            t_A = Avx2.UnpackLow(x_A, x_B);
+            t_B = Avx2.UnpackLow(x_C, x_D);
+            t_C = Avx2.UnpackHigh(x_A, x_B);
+            t_D = Avx2.UnpackHigh(x_C, x_D);
+            x_A = Avx2.UnpackLow(t_A.AsUInt64(), t_B.AsUInt64()).AsUInt32();
+            x_B = Avx2.UnpackHigh(t_A.AsUInt64(), t_B.AsUInt64()).AsUInt32();
+            x_C = Avx2.UnpackLow(t_C.AsUInt64(), t_D.AsUInt64()).AsUInt32();
+            x_D = Avx2.UnpackHigh(t_C.AsUInt64(), t_D.AsUInt64()).AsUInt32();
+        }
+        // End of 512 byte methods
+    }
+}
+#pragma warning restore IDE0007 // Use implicit type
+#endif

--- a/src/NaCl.Core/Base/SnufflePoly1305.cs
+++ b/src/NaCl.Core/Base/SnufflePoly1305.cs
@@ -291,19 +291,13 @@
         /// <param name="aad">The associated data.</param>
         /// <param name="ciphertext">The ciphertext.</param>
         /// <returns>System.Byte[].</returns>
-        [ThreadStatic]
-        private static byte[] macDataBytes = new byte[0];
         private ReadOnlySpan<byte> GetMacDataRfc8439(ReadOnlySpan<byte> aad, ReadOnlySpan<byte> ciphertext)
         {
             var aadPaddedLen = (aad.Length % 16 == 0) ? aad.Length : (aad.Length + 16 - aad.Length % 16);
             var ciphertextLen = ciphertext.Length;
             var ciphertextPaddedLen = (ciphertextLen % 16 == 0) ? ciphertextLen : (ciphertextLen + 16 - ciphertextLen % 16);
-            var macDataLength = aadPaddedLen + ciphertextPaddedLen + 16;
 
-            if (macDataBytes.Length < macDataLength)
-                macDataBytes = new byte[macDataLength];
-
-            Span<byte> macData = macDataBytes;
+            Span<byte> macData = new byte[aadPaddedLen + ciphertextPaddedLen + 16];
 
             // Mac Text
             aad.CopyTo(macData);

--- a/src/NaCl.Core/Internal/SpanOwner.cs
+++ b/src/NaCl.Core/Internal/SpanOwner.cs
@@ -1,0 +1,163 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+//using Microsoft.Toolkit.HighPerformance.Buffers.Views;
+//using Microsoft.Toolkit.HighPerformance.Extensions;
+
+namespace Microsoft.Toolkit.HighPerformance.Buffers
+{
+    /// <summary>
+    /// An <see langword="enum"/> that indicates a mode to use when allocating buffers.
+    /// </summary>
+    public enum AllocationMode
+    {
+        /// <summary>
+        /// The default allocation mode for pooled memory (rented buffers are not cleared).
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Clear pooled buffers when renting them.
+        /// </summary>
+        Clear
+    }
+
+    /// <summary>
+    /// A stack-only type with the ability to rent a buffer of a specified length and getting a <see cref="Span{T}"/> from it.
+    /// This type mirrors <see cref="MemoryOwner{T}"/> but without allocations and with further optimizations.
+    /// As this is a stack-only type, it relies on the duck-typed <see cref="IDisposable"/> pattern introduced with C# 8.
+    /// It should be used like so:
+    /// <code>
+    /// using (SpanOwner&lt;byte> buffer = SpanOwner&lt;byte>.Allocate(1024))
+    /// {
+    ///     // Use the buffer here...
+    /// }
+    /// </code>
+    /// As soon as the code leaves the scope of that <see langword="using"/> block, the underlying buffer will automatically
+    /// be disposed. The APIs in <see cref="SpanOwner{T}"/> rely on this pattern for extra performance, eg. they don't perform
+    /// the additional checks that are done in <see cref="MemoryOwner{T}"/> to ensure that the buffer hasn't been disposed
+    /// before returning a <see cref="Memory{T}"/> or <see cref="Span{T}"/> instance from it.
+    /// As such, this type should always be used with a <see langword="using"/> block or expression.
+    /// Not doing so will cause the underlying buffer not to be returned to the shared pool.
+    /// </summary>
+    /// <typeparam name="T">The type of items to store in the current instance.</typeparam>
+    //[DebuggerTypeProxy(typeof(SpanOwnerDebugView<>))]
+    [DebuggerDisplay("{ToString(),raw}")]
+    public readonly ref struct SpanOwner<T>
+    {
+#pragma warning disable IDE0032
+        /// <summary>
+        /// The usable length within <see cref="array"/>.
+        /// </summary>
+        private readonly int length;
+#pragma warning restore IDE0032
+
+        /// <summary>
+        /// The underlying <typeparamref name="T"/> array.
+        /// </summary>
+        private readonly T[] array;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpanOwner{T}"/> struct with the specified parameters.
+        /// </summary>
+        /// <param name="length">The length of the new memory buffer to use.</param>
+        /// <param name="mode">Indicates the allocation mode to use for the new buffer to rent.</param>
+        private SpanOwner(int length, AllocationMode mode)
+        {
+            this.length = length;
+            this.array = ArrayPool<T>.Shared.Rent(length);
+
+            if (mode == AllocationMode.Clear)
+            {
+                this.array.AsSpan(0, length).Clear();
+            }
+        }
+
+        /// <summary>
+        /// Gets an empty <see cref="SpanOwner{T}"/> instance.
+        /// </summary>
+        public static SpanOwner<T> Empty
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new SpanOwner<T>(0, AllocationMode.Default);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="SpanOwner{T}"/> instance with the specified parameters.
+        /// </summary>
+        /// <param name="size">The length of the new memory buffer to use.</param>
+        /// <returns>A <see cref="SpanOwner{T}"/> instance of the requested length.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is not valid.</exception>
+        /// <remarks>This method is just a proxy for the <see langword="private"/> constructor, for clarity.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SpanOwner<T> Allocate(int size) => new SpanOwner<T>(size, AllocationMode.Default);
+
+        /// <summary>
+        /// Creates a new <see cref="SpanOwner{T}"/> instance with the specified parameters.
+        /// </summary>
+        /// <param name="size">The length of the new memory buffer to use.</param>
+        /// <param name="mode">Indicates the allocation mode to use for the new buffer to rent.</param>
+        /// <returns>A <see cref="SpanOwner{T}"/> instance of the requested length.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="size"/> is not valid.</exception>
+        /// <remarks>This method is just a proxy for the <see langword="private"/> constructor, for clarity.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SpanOwner<T> Allocate(int size, AllocationMode mode) => new SpanOwner<T>(size, mode);
+
+        /// <summary>
+        /// Gets the number of items in the current instance
+        /// </summary>
+        public int Length
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this.length;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="Span{T}"/> wrapping the memory belonging to the current instance.
+        /// </summary>
+        public Span<T> Span
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new Span<T>(array, 0, this.length);
+        }
+
+        /// <summary>
+        /// Returns a reference to the first element within the current instance, with no bounds check.
+        /// </summary>
+        /// <returns>A reference to the first element within the current instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ref T DangerousGetReference()
+        {
+            //return ref array.DangerousGetReference();
+            return ref MemoryMarshal.GetReference<T>(array);
+        }
+
+        /// <summary>
+        /// Implements the duck-typed <see cref="IDisposable.Dispose"/> method.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+            ArrayPool<T>.Shared.Return(array);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            if (typeof(T) == typeof(char) &&
+                this.array is char[] chars)
+            {
+                return new string(chars, 0, this.length);
+            }
+
+            // Same representation used in Span<T>
+            return $"Microsoft.Toolkit.HighPerformance.Buffers.SpanOwner<{typeof(T)}>[{this.length}]";
+        }
+    }
+}

--- a/src/NaCl.Core/NaCl.Core.csproj
+++ b/src/NaCl.Core/NaCl.Core.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp3.1;net45;net48</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp3.1;netcoreapp5.0;net45;net48</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>1.2.0</Version>
     <Authors>David De Smet</Authors>
@@ -26,10 +26,11 @@
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
-  <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
-    <DefineConstants>FCL_BITOPS</DefineConstants>
+  <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp3.0' OR $(TargetFramework) == 'netcoreapp3.1' OR $(TargetFramework) == 'netcoreapp5.0'">
+    <DefineConstants>FCL_BITOPS;INTRINSICS;SPANSTACKALLOC</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-
+  
   <Target Name="LogDebugInfo">
     <Message Text="Building for $(TargetFramework) on $(OS)" Importance="High" />
   </Target>

--- a/src/NaCl.Core/NaCl.Core.csproj
+++ b/src/NaCl.Core/NaCl.Core.csproj
@@ -15,6 +15,7 @@
     <RepositoryUrl>https://github.com/idaviddesmet/NaCl.Core.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>master</RepositoryBranch>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/NaCl.Core.Benchmarks/ChaCha20Poly1305Benchmark.cs
+++ b/test/NaCl.Core.Benchmarks/ChaCha20Poly1305Benchmark.cs
@@ -20,7 +20,8 @@
         private byte[] message;
         private byte[] tag;
         private byte[] aad;
-        
+        private Memory<byte> ciphertext;
+
         private ChaCha20Poly1305 aead;
 
         [Params(
@@ -50,14 +51,15 @@
             rnd.NextBytes(aad);
 
             aead = new ChaCha20Poly1305(key);
+
+            ciphertext = new byte[message.Length];
         }
 
         [Benchmark]
         [BenchmarkCategory("Encryption")]
         public void Encrypt()
         {
-            var ciphertext = new byte[message.Length];
-            aead.Encrypt(nonce, message, ciphertext, tag, aad);
+            aead.Encrypt(nonce, message, ciphertext.Span, tag, aad);
         }
 
         [Benchmark]

--- a/test/NaCl.Core.Benchmarks/NaCl.Core.Benchmarks.csproj
+++ b/test/NaCl.Core.Benchmarks/NaCl.Core.Benchmarks.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NaCl.Core.Benchmarks/Program.cs
+++ b/test/NaCl.Core.Benchmarks/Program.cs
@@ -10,12 +10,13 @@
         {
             // Execute following code:
             // $ dotnet run -c release --framework netcoreapp3.1
-            //BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-            BenchmarkRunner.Run<Poly1305Benchmark>();
-            BenchmarkRunner.Run<ChaCha20Benchmark>();
-            BenchmarkRunner.Run<ChaCha20Poly1305Benchmark>();
-            BenchmarkRunner.Run<XChaCha20Benchmark>();
-            BenchmarkRunner.Run<XChaCha20Poly1305Benchmark>();
+
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+            //BenchmarkRunner.Run<Poly1305Benchmark>(args);
+            //BenchmarkRunner.Run<ChaCha20Benchmark>(args);
+            //BenchmarkRunner.Run<ChaCha20Poly1305Benchmark>(args);
+            //BenchmarkRunner.Run<XChaCha20Benchmark>(args);
+            //BenchmarkRunner.Run<XChaCha20Poly1305Benchmark>(args);
 
             Console.ReadLine();
         }

--- a/test/NaCl.Core.Benchmarks/RandomNumberGenerator.cs
+++ b/test/NaCl.Core.Benchmarks/RandomNumberGenerator.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace NaCl.Core.Benchmarks
+{
+#if NET48
+    public static class RandomNumberGenerator
+    {
+        public static void Fill(Span<byte> data)
+        {
+            var random = System.Security.Cryptography.RandomNumberGenerator.Create();
+            var dataBytes = new byte[data.Length];
+            random.GetBytes(dataBytes);
+            dataBytes.CopyTo(data);
+        }
+    }
+#endif
+}

--- a/test/NaCl.Core.Benchmarks/Run benchmarks.bat
+++ b/test/NaCl.Core.Benchmarks/Run benchmarks.bat
@@ -1,0 +1,1 @@
+dotnet run -c Release -f netcoreapp3.1 --runtimes net48 netcoreapp3.1

--- a/test/NaCl.Core.Tests/NaCl.Core.Tests.csproj
+++ b/test/NaCl.Core.Tests/NaCl.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -23,6 +23,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.categories" Version="2.0.4" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">

--- a/test/NaCl.Core.Tests/RandomNumberGenerator.cs
+++ b/test/NaCl.Core.Tests/RandomNumberGenerator.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace NaCl.Core.Tests
+{
+#if NET48
+    public static class RandomNumberGenerator
+    {
+        public static void Fill(Span<byte> data)
+        {
+            var random = System.Security.Cryptography.RandomNumberGenerator.Create();
+            var dataBytes = new byte[data.Length];
+            random.GetBytes(dataBytes);
+            dataBytes.CopyTo(data);
+        }
+    }
+#endif
+}


### PR DESCRIPTION
- Added Intrinsics fast path
- Added ability for benchmarks to run in .NET48 (for a pre/post intrinsics comparison)

Hello!

I finally got round to pulling in all your latest updates. Fantastic work on the Span & BitUtils support.

A quick bit of benchmarking. 
Before adding my pure intrinsics processing (i.e. using BitUtils which I suspect emits some intrinsics under the hood):

![image](https://user-images.githubusercontent.com/1031306/91615634-ecb8ba80-e97b-11ea-8fa9-e458b4b02987.png)

A decent improvement vs. Framework.

After adding intrinsics:

![image](https://user-images.githubusercontent.com/1031306/91615672-fd693080-e97b-11ea-9c91-2155e22938b5.png)

I'm particularly impressed with the memory allocated when using the Span Encrypt method. When I did a memory trace, the `GetMacDataRfc8439` was the only method significantly allocating memory. It would be ideal to come up with some sort of caching or memory context scheme for this.

